### PR TITLE
Added show only in articles option

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -14,8 +14,32 @@ defined('_JEXEC') or die;
 JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
 JModelLegacy::addIncludePath(JPATH_SITE . '/components/com_content/models', 'ContentModel');
 
-class modarticlesthumbnailsHelper {
-    static function getItems($params){
+class modarticlesthumbnailsHelper
+{
+	static function getItems($params)
+	{
+		// Set application parameters in model
+		$app       = JFactory::getApplication();
+		$appParams = $app->getParams();
+		
+		$option = $app->input->get('option');
+    	$view   = $app->input->get('view');
+		
+		$onlyInArticles = $params->get('show_only_in_articles');
+		
+		$relatedArticles = true;
+
+        if ($onlyInArticles)
+        {
+    		$option = $app->input->get('option');
+    		$view   = $app->input->get('view');
+            
+            if (!($option === 'com_content' && $view === 'article'))
+    		{
+    			return array();
+    		}
+		}
+		
 		// Get an instance of the generic articles model
 		$model     = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
 		

--- a/mod_articles_thumbnails.php
+++ b/mod_articles_thumbnails.php
@@ -12,6 +12,12 @@ defined('_JEXEC') or die;
 JLoader::register('modarticlesthumbnailsHelper', __DIR__ . '/helper.php');
 
 $items = modarticlesthumbnailsHelper::getItems($params);
+
+if (!count($items))
+{
+	return;
+}
+
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 $layout = $params->get('layout', 'default');
 switch((int)$params->get('templateframework', 1))

--- a/mod_articles_thumbnails.xml
+++ b/mod_articles_thumbnails.xml
@@ -57,6 +57,17 @@
 					<option value="1">JSHOW</option>
 					<option value="0">JHIDE</option>
 				</field>
+				<field
+					name="show_only_in_articles"
+					type="radio"
+					label="MOD_ARTICLES_THUMBNAILS_FIELD_ONLY_IN_ARTICLES_LABEL"
+					description="MOD_ARTICLES_THUMBNAILS_FIELD_ONLY_IN_ARTICLES_DESC"
+					class="btn-group btn-group-yesno"
+					default="1"
+					>
+					<option value="1">JYES</option>
+					<option value="0">JNO</option>
+				</field>
 
 				<field
 					name="templateframework"


### PR DESCRIPTION
This PR adds the option to only show items when you are in an article view. Very useful if you only want to show your thumbnails in your article view.

Also this is the first step to the other feature I'm working on: **Show related thumbnails** Which will allow showing only articles somehow related to the displayed article.